### PR TITLE
feat(checks): placeholder directives, fields sections, convertibility-aware severity

### DIFF
--- a/grantkit/core/builder.py
+++ b/grantkit/core/builder.py
@@ -139,9 +139,15 @@ def _assemble_plaintext_blocks(project: "GrantProject") -> str:
         "Plain-text portal: paste each block below into its portal box.\n"
     )
     for section in project.sections:
-        body = _to_plaintext(section.body) if section.exists else ""
-        limit = f" / {section.word_limit}" if section.word_limit else ""
-        label = f"{section.title}  ({section.words}{limit} words)"
+        if section.format == "fields":
+            # Individual form fields, typed one by one — keep the source
+            # (tables and all) as an on-screen reference, not a paste block.
+            label = f"{section.title}  (form fields — enter individually)"
+            body = section.body.strip() if section.exists else ""
+        else:
+            body = _to_plaintext(section.body) if section.exists else ""
+            limit = f" / {section.word_limit}" if section.word_limit else ""
+            label = f"{section.title}  ({section.words}{limit} words)"
         parts.append("-" * 70)
         parts.append(label)
         parts.append("-" * 70)
@@ -155,6 +161,7 @@ def _to_plaintext(markdown_text: str) -> str:
     import re
 
     text = markdown_text
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)  # HTML comments
     text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)  # headers
     text = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", text)  # links
     text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)  # bold

--- a/grantkit/core/checks.py
+++ b/grantkit/core/checks.py
@@ -239,24 +239,35 @@ def _check_markdown(project: "GrantProject") -> list[CheckItem]:
                 )
             )
 
-    # 2. Plain-text portals: any Markdown syntax is a problem.
+    # 2. Plain-text portals. Constructs `grantkit build` converts cleanly
+    # (headers, emphasis, links, inline code, lists) are warnings — paste
+    # from the built copy blocks, not the source file. Constructs that
+    # survive conversion (tables, HTML comments) are errors. `fields`
+    # sections hold individual form values, not pasted prose, so they are
+    # not linted here.
     if not project.accepts_markdown:
         citation = _plain_text_citation(project.pack)
         validator = MarkdownContentValidator(accepts_markdown=False)
         for section in project.sections:
-            if not section.exists:
+            if not section.exists or section.format == "fields":
                 continue
             result = validator.validate_content(section.body, section.id)
             for violation in result.violations:
+                converts = violation.syntax_type not in ("table", "comment")
                 out.append(
                     CheckItem(
-                        level="error",
+                        level="warning" if converts else "error",
                         rule="markdown_in_plain_text",
                         message=(
                             f"{violation.message} on line "
-                            f"{violation.line_number} — this portal accepts "
-                            f"plain text only, so Markdown would be pasted "
-                            f"literally."
+                            f"{violation.line_number} — "
+                            + (
+                                "stripped cleanly in the built copy blocks; "
+                                "paste from the build output, not this file."
+                                if converts
+                                else "this does not convert to plain text "
+                                "and would be pasted literally."
+                            )
                         ),
                         section=section.id,
                         citation=citation,
@@ -380,12 +391,17 @@ def _check_budget(
             )
         grand_total = calc.calculate_grand_total()
         yearly = calc.calculate_yearly_totals()
-    except Exception as exc:
+    except Exception:
         return out + [
             CheckItem(
                 level="warning",
-                rule="budget_unreadable",
-                message=f"Could not compute budget totals: {exc}",
+                rule="budget_schema_mismatch",
+                message=(
+                    f"{budget_path.name} does not match grantkit's budget "
+                    "schema (see docs), so arithmetic and cap checks were "
+                    "skipped. Verify totals another way, or omit the file "
+                    "from grantkit's view by renaming it."
+                ),
             )
         ]
 

--- a/grantkit/core/project.py
+++ b/grantkit/core/project.py
@@ -39,6 +39,10 @@ PLACEHOLDER_PATTERNS: list[re.Pattern] = [
     re.compile(r"(?<![A-Za-z])TBD(?![A-Za-z])"),
     re.compile(r"(?<![A-Za-z])FIXME(?![A-Za-z])"),
     re.compile(r"(?<![A-Za-z])XXX(?![A-Za-z])"),
+    # Bracketed directives naming a person or action, e.g. [MAX: phone
+    # number], [AK: confirm], and the [NEED INPUT] convention.
+    re.compile(r"\[[A-Z]{2,10}:[^\]]{0,100}\]"),
+    re.compile(r"\[\s*need\s+input[^\]]*\]", re.IGNORECASE),
 ]
 
 # Legacy funder keys whose nested `sections` we still understand.
@@ -84,6 +88,10 @@ class SectionState:
     word_limit: Optional[int] = None
     char_limit: Optional[int] = None
     page_limit: Optional[int] = None
+    #: ``prose`` sections are pasted into portal text boxes as a unit;
+    #: ``fields`` sections hold individual form fields (tables of values
+    #: typed one by one), so plain-text portal linting does not apply.
+    format: str = "prose"
     exists: bool = False
     body: str = ""
     words: int = 0
@@ -205,6 +213,11 @@ class GrantProject:
                 word_limit=raw.get("word_limit"),
                 char_limit=raw.get("char_limit"),
                 page_limit=raw.get("page_limit"),
+                format=(
+                    raw["format"]
+                    if raw.get("format") in ("prose", "fields")
+                    else "prose"
+                ),
             )
             self._compute_section(section)
             self.sections.append(section)

--- a/grantkit/packs/schema.py
+++ b/grantkit/packs/schema.py
@@ -26,7 +26,9 @@ Schema (top-level keys)
 ``sections`` (list, optional)
     Section definitions used to scaffold a grant. Each carries
     ``id``/``title``/``word_limit``/``char_limit``/``page_limit``/``required``/
-    ``description``/``file``/``stage``.
+    ``description``/``file``/``stage``/``format`` (``prose`` | ``fields``;
+    ``fields`` sections hold individual form values and are exempt from
+    plain-text portal linting).
 ``formatting_rules`` (list, optional)
     Documented formatting rules. Each carries ``id``/``description``/``severity``/
     ``citation``/``url``/``quote``/``applies_to``.
@@ -48,6 +50,7 @@ from typing import Any, Optional
 VALID_SEVERITIES = {"error", "warning", "info"}
 VALID_LOCALES = {"en-US", "en-GB"}
 VALID_CONTENT_ENGINES = {None, "nsf_pappg"}
+VALID_SECTION_FORMATS = {"prose", "fields"}
 
 
 @dataclass
@@ -63,6 +66,9 @@ class PackSection:
     description: Optional[str] = None
     file: Optional[str] = None
     stage: Optional[str] = None
+    #: ``prose`` (default) is pasted as a portal text box; ``fields`` holds
+    #: individual form values and is exempt from plain-text portal linting.
+    format: str = "prose"
 
 
 @dataclass
@@ -153,6 +159,11 @@ class FunderPack:
                 description=s.get("description"),
                 file=s.get("file"),
                 stage=s.get("stage"),
+                format=(
+                    s["format"]
+                    if s.get("format") in VALID_SECTION_FORMATS
+                    else "prose"
+                ),
             )
             for s in data.get("sections", []) or []
         ]
@@ -286,6 +297,15 @@ def validate_pack(data: Any) -> list[str]:
             ):
                 errors.append(
                     f"{where} ('{sid}') 'required' must be a boolean"
+                )
+            if (
+                "format" in section
+                and section["format"] not in VALID_SECTION_FORMATS
+            ):
+                errors.append(
+                    f"{where} ('{sid}') invalid format "
+                    f"'{section['format']}' "
+                    f"(allowed: {sorted(VALID_SECTION_FORMATS)})"
                 )
 
     # Formatting rules

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -124,3 +124,51 @@ def test_build_rejects_unknown_format(make_grant, simple_config):
     )
     with pytest.raises(ValueError):
         build_project(project, fmt="rtf")
+
+
+def test_plaintext_blocks_render_fields_sections_verbatim(tmp_path):
+    import yaml as _yaml
+
+    from grantkit.core.builder import _assemble_plaintext_blocks
+    from grantkit.core.project import GrantProject
+
+    (tmp_path / "responses").mkdir()
+    (tmp_path / "responses" / "pi.md").write_text(
+        "| Field | Value |\n|---|---|\n| Name | Max |\n"
+    )
+    (tmp_path / "responses" / "a.md").write_text("Some **bold** prose.\n")
+    (tmp_path / "grant.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "title": "T",
+                "accepts_markdown": False,
+                "sections": [
+                    {
+                        "id": "pi",
+                        "title": "PI details",
+                        "format": "fields",
+                        "file": "responses/pi.md",
+                    },
+                    {
+                        "id": "a",
+                        "title": "Summary",
+                        "file": "responses/a.md",
+                        "word_limit": 100,
+                    },
+                ],
+            }
+        )
+    )
+    blocks = _assemble_plaintext_blocks(GrantProject(tmp_path))
+    assert "PI details  (form fields — enter individually)" in blocks
+    assert "| Name | Max |" in blocks  # fields table kept verbatim
+    assert "Some bold prose." in blocks  # emphasis stripped in prose
+    assert "**bold**" not in blocks
+
+
+def test_to_plaintext_strips_html_comments():
+    from grantkit.core.builder import _to_plaintext
+
+    assert _to_plaintext("Keep this.<!-- reviewer note\nspanning -->") == (
+        "Keep this."
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -101,14 +101,15 @@ def test_plain_text_portal_flags_markdown(make_grant, simple_config):
     root = make_grant(
         config,
         {
-            "responses/summary.md": "# A heading\n\nBody text.",
+            # Heading converts cleanly in build -> warning; table doesn't -> error.
+            "responses/summary.md": "# A heading\n\n| a | b |\n|---|---|\n",
             "responses/narrative.md": "Plain text is fine here.",
         },
     )
     result = _run(root)
     md = [i for i in result.items if i.rule == "markdown_in_plain_text"]
-    assert md and all(i.level == "error" for i in md)
-    assert md[0].section == "summary"
+    assert md and all(i.section == "summary" for i in md)
+    assert {i.level for i in md} == {"warning", "error"}
 
 
 def test_spelling_locale_warns(make_grant, simple_config):
@@ -206,3 +207,94 @@ def test_check_item_to_dict_shape():
     d = item.to_dict()
     assert set(d) == {"level", "rule", "message", "section", "citation"}
     assert d["level"] == "error"
+
+
+def test_placeholders_catch_bracketed_directives(tmp_path):
+    from grantkit.core.project import find_placeholders
+
+    text = (
+        "Phone: [MAX: phone number]\n"
+        "Budget: [NEED INPUT]\n"
+        "Bios: [AK: confirm wording]\n"
+        "Not placeholders: [2026 figures](https://example.com) and [@cite2026]."
+    )
+    found = find_placeholders(text)
+    assert "[MAX: phone number]" in found
+    assert "[NEED INPUT]" in found
+    assert "[AK: confirm wording]" in found
+    assert not any("example.com" in f or "@cite" in f for f in found)
+
+
+def _plain_text_project(tmp_path, sections_yaml, files):
+    import yaml as _yaml
+
+    from grantkit.core.project import GrantProject
+
+    (tmp_path / "responses").mkdir(exist_ok=True)
+    for rel, body in files.items():
+        (tmp_path / rel).write_text(body)
+    (tmp_path / "grant.yaml").write_text(
+        _yaml.safe_dump(
+            {
+                "title": "T",
+                "accepts_markdown": False,
+                "sections": sections_yaml,
+            }
+        )
+    )
+    return GrantProject(tmp_path)
+
+
+def test_fields_sections_skip_plain_text_linting(tmp_path):
+    from grantkit.core.checks import run_checks
+
+    project = _plain_text_project(
+        tmp_path,
+        [
+            {
+                "id": "pi",
+                "title": "PI details",
+                "format": "fields",
+                "file": "responses/pi.md",
+            },
+            {"id": "a", "title": "Summary", "file": "responses/a.md"},
+        ],
+        {
+            "responses/pi.md": "| Field | Value |\n|---|---|\n| Name | Max |\n",
+            "responses/a.md": "Plain prose only.\n",
+        },
+    )
+    items = run_checks(project).items
+    md = [i for i in items if i.rule == "markdown_in_plain_text"]
+    assert md == []
+
+
+def test_plain_text_severity_splits_by_convertibility(tmp_path):
+    from grantkit.core.checks import run_checks
+
+    project = _plain_text_project(
+        tmp_path,
+        [{"id": "a", "title": "Summary", "file": "responses/a.md"}],
+        {
+            "responses/a.md": (
+                "Some **bold** claim.\n\n" "| a | b |\n|---|---|\n| 1 | 2 |\n"
+            )
+        },
+    )
+    items = [
+        i
+        for i in run_checks(project).items
+        if i.rule == "markdown_in_plain_text"
+    ]
+    levels = {}
+    for item in items:
+        key = "table" if "convert" in item.message else "inline"
+        levels.setdefault(key, set()).add(item.level)
+    # Bold converts cleanly -> warning; tables survive -> error.
+    assert any(i.level == "warning" for i in items)
+    assert any(i.level == "error" for i in items)
+    for item in items:
+        if item.level == "error":
+            assert "does not convert" in item.message
+        else:
+            assert "paste from the build output" in item.message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,9 +44,9 @@ def test_check_exit_codes(tmp_path):
     result = runner.invoke(main, ["check", "--strict", str(tmp_path)])
     assert result.exit_code == 1
 
-    # Introduce an error (markdown in a plain-text portal).
+    # Introduce an error (a table survives plain-text conversion).
     (tmp_path / "responses" / "project_summary.md").write_text(
-        "# heading not allowed in plain text\n", encoding="utf-8"
+        "| a | b |\n|---|---|\n| 1 | 2 |\n", encoding="utf-8"
     )
     result = runner.invoke(main, ["check", str(tmp_path)])
     assert result.exit_code == 1

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -192,3 +192,23 @@ def test_resolve_pack_by_id_and_name():
 def test_resolve_pack_unknown_returns_none():
     assert resolve_pack("not-a-real-funder-xyz") is None
     assert resolve_pack(None) is None
+
+
+def test_pack_schema_rejects_invalid_section_format():
+    from grantkit.packs.schema import validate_pack
+
+    errors = validate_pack(
+        {
+            "id": "x",
+            "name": "X",
+            "sections": [{"id": "s", "title": "S", "format": "tabular"}],
+        }
+    )
+    assert any("invalid format" in e for e in errors)
+    assert not validate_pack(
+        {
+            "id": "x",
+            "name": "X",
+            "sections": [{"id": "s", "title": "S", "format": "fields"}],
+        }
+    )

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -110,7 +110,7 @@ def test_status_checks_items_shape(make_grant, simple_config):
         make_grant,
         config,
         {
-            "responses/summary.md": "# Heading makes a plain-text error",
+            "responses/summary.md": "| a | b |\n|---|---|\n| 1 | 2 |",
             "responses/narrative.md": "plain text ok",
         },
     )


### PR DESCRIPTION
Fixes from running the engine against a real plain-text-portal application (Nuffield rapid-response, 13 sections, drafted before GrantKit):

- **Placeholder detection** catches bracketed directives: `[MAX: phone number]`, `[AK: confirm]`, `[NEED INPUT]`.
- **`format: prose|fields` per section** — fields sections (Field/Value tables typed individually into the portal) skip plain-text linting; build renders them verbatim as reference, not paste blocks.
- **Severity by convertibility** — headers/emphasis/links/inline code become warnings ("paste from the build output"); tables and HTML comments remain errors. Before this, a real application produced 91 errors, ~85 of them false alarms.
- `_to_plaintext` strips HTML comments; budget schema mismatch gets an actionable message instead of a raw exception.

214 tests pass (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
